### PR TITLE
Bruk env-variabel for kudaf-url

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,7 +22,7 @@ url:
     api: ${RESOURCE_SERVICE_URI}
     frontend: ${FDK_URI}
   kudaf:
-    soknadApi: https://frontend-soknad-api.paas2.uninett.no
+    soknadApi: ${KUDAF_FRONTEND_SOKNAD_API:https://frontend-soknad-api.paas2.uninett.no}
 
 application:
   cors:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,7 +22,7 @@ url:
     api: ${RESOURCE_SERVICE_URI}
     frontend: ${FDK_URI}
   kudaf:
-    soknadApi: ${KUDAF_FRONTEND_SOKNAD_API:https://frontend-soknad-api.paas2.uninett.no}
+    soknadApi: ${KUDAF_FRONTEND_SOKNAD_API:https://frontend-soknad-api-staging.sokrates.edupaas.no/}
 
 application:
   cors:


### PR DESCRIPTION
Kudaf har nå eget stagingmiljø. Endrer til å hente fra env variabel KUDAF_FRONTEND_SOKNAD_API. Defaulter til å hente fra https://frontend-soknad-api-staging.paas2.uninett.no

Må nok endre i deploy/prod/env.yaml og deploy/dev/env.yaml også 👀 

Prodverdi: https://frontend-soknad-api.paas2.uninett.no
Devverdi: https://frontend-soknad-api-staging.sokrates.edupaas.no
